### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -21,7 +21,7 @@ Resources:
     Properties:
       CodeUri: src/recieveUser
       Handler: app.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Policies:
         - Version: '2012-10-17'
           Statement:
@@ -46,7 +46,7 @@ Resources:
     Properties:
       CodeUri: src/validatePolicy
       Handler: app.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Environment:
         Variables:
           restrictedActions: !Ref "restrictedActions"
@@ -56,7 +56,7 @@ Resources:
     Properties:
       CodeUri: src/policyChangerApprove
       Handler: app.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Policies:
         - Version: '2012-10-17'
           Statement:
@@ -73,7 +73,7 @@ Resources:
     Properties:
       CodeUri: src/revertPolicy
       Handler: app.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Policies:
         - Version: '2012-10-17'
           Statement:
@@ -90,7 +90,7 @@ Resources:
     Properties:
       CodeUri: src/askUser
       Handler: app.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Policies:
         - Version: '2012-10-17'
           Statement:


### PR DESCRIPTION
CloudFormation templates in automating-a-security-incident-with-step-functions have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.